### PR TITLE
fix: install on newer pi os

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -31,7 +31,7 @@ echo "----------------------------------------------"
 echo "installed needed packages for python          "
 echo "----------------------------------------------"
 
-sudo apt-get install -y python3 python3-gi python3-gi-cairo gir1.2-gtk-3.0 python3-pip libatlas-base-dev libglib2.0-dev libgirepository1.0-dev libcairo2-dev zlib1g-dev libfreetype6-dev liblcms2-dev libopenjp2-7 libtiff5
+sudo apt-get install -y python3 python3-gi python3-venv python3-gi-cairo gir1.2-gtk-3.0 python3-pip libatlas-base-dev libglib2.0-dev libgirepository1.0-dev libcairo2-dev zlib1g-dev libfreetype6-dev liblcms2-dev libopenjp2-7 libtiff6 build-essential libpython3-dev libdbus-1-dev
 
 echo " "
 
@@ -42,7 +42,7 @@ echo "install needed python3 modules for the project        "
 echo "----------------------------------------------"
 echo " "
 
-sudo pip3 install -r requirements.txt
+sudo pip3 install --break-system-packages -r requirements.txt
 
 echo " "
 echo "-------------------------------------------------------"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pyserial == 3.5
-PyGObject == 3.38.0
-dbus-python == 1.2.18
+PyGObject == 3.50.0
+dbus-python == 1.3.2
 pyusb == 1.2.0
 gatt == 0.2.7
 supervisor == 4.2.1


### PR DESCRIPTION
Update apt package dependencies to fit newer distributions. Adapt pip3 command to skip required venv activation because these are the only python dependencies installed on this system.